### PR TITLE
Do not share drawables state with any other drawable.

### DIFF
--- a/bottom-navigation/src/main/java/it/sephiroth/android/library/bottomnavigation/BottomNavigation.java
+++ b/bottom-navigation/src/main/java/it/sephiroth/android/library/bottomnavigation/BottomNavigation.java
@@ -492,6 +492,7 @@ public class BottomNavigation extends FrameLayout implements OnItemClickListener
 
         // Main background
         layerDrawable = (LayerDrawable) ContextCompat.getDrawable(getContext(), bgResId);
+        layerDrawable.mutate();
         backgroundDrawable = (ColorDrawable) layerDrawable.findDrawableByLayerId(R.id.bbn_background);
         setBackground(layerDrawable);
 

--- a/bottom-navigation/src/main/java/it/sephiroth/android/library/bottomnavigation/BottomNavigationItemViewAbstract.java
+++ b/bottom-navigation/src/main/java/it/sephiroth/android/library/bottomnavigation/BottomNavigationItemViewAbstract.java
@@ -40,6 +40,7 @@ abstract class BottomNavigationItemViewAbstract extends View {
 
     void setItem(BottomNavigationItem item) {
         final Drawable drawable = ContextCompat.getDrawable(getContext(), R.drawable.bbn_ripple_selector);
+        drawable.mutate();
         MiscUtils.setDrawableColor(drawable, rippleColor);
 
         this.item = item;


### PR DESCRIPTION
Make drawables mutable, so they don't change the state of other drawables.

E.g. 
Android uses cache for `ColorDrawable` and shares them across application, so e.g. when you change `@android:color/white` it also changes all color drawables that have the same initial value.

[Drawable.mutate()](http://developer.android.com/reference/android/graphics/drawable/Drawable.html#mutate%28%29)